### PR TITLE
Now docs builder tries to load system using either Quicklisp client o…

### DIFF
--- a/src/changelog.lisp
+++ b/src/changelog.lisp
@@ -1,7 +1,9 @@
 (uiop:define-package #:docs-builder/changelog
   (:use #:cl)
   (:import-from #:40ants-doc/changelog
-                #:defchangelog))
+                #:defchangelog)
+  (:import-from #:docs-builder
+                #:build))
 (in-package docs-builder/changelog)
 
 
@@ -11,6 +13,10 @@
                               "ERROR-ON-WARNINGS"
                               "DYNAMIC-BINDINGS")
                :external-docs ("https://40ants.com/doc/"))
+  (0.11.0 2023-06-05
+          "* Now docs builder tries to load system using either Quicklisp client or ASDF if system is not already loaded.
+           * Also a bug was fixed - previously BUILD function hanged in recursion in case if asdf system wasn't found.
+             Now it will show an error.")
   (0.10.0 2022-11-16
           "Support new refactored 40ANTS-DOC system.")
   (0.9.1 2022-10-26

--- a/src/guesser.lisp
+++ b/src/guesser.lisp
@@ -26,12 +26,28 @@ If you want to add support for a new documentation generator, use DEFGUESSER mac
      (pushnew ',name *guessers*)))
 
 
+(defun find-or-load-system (system-name)
+  (let ((system (asdf:registered-system system-name)))
+    (cond
+      (system system)
+      (t
+       (let ((system (progn
+                       #+quicklisp
+                       (ql:quickload system-name)
+                       #-quicklisp
+                       (asdf:load-system system-name)
+                       (asdf:registered-system system-name))))
+         (unless system
+           (error "Unable to load system \"~A\" ensure it is accessible to ASDF or Quicklisp."
+                  system-name))
+         (values system))))))
+
 (defmethod guess-builder ((system symbol))
-  (guess-builder (asdf:registered-system system)))
+  (guess-builder (find-or-load-system system)))
 
 
 (defmethod guess-builder ((system string))
-  (guess-builder (asdf:registered-system system)))
+  (guess-builder (find-or-load-system system)))
 
 
 (defmethod guess-builder ((system asdf:system))


### PR DESCRIPTION
…r ASDF if system is not already loaded.

Also a bug was fixed - previously BUILD function hanged in recursion in case if asdf system wasn't found. Now it will show an error.